### PR TITLE
Removing searchPingableDevicesAndSetThemUpByHostName for now

### DIFF
--- a/lib/application/boot_up/boot_up.dart
+++ b/lib/application/boot_up/boot_up.dart
@@ -31,7 +31,11 @@ class BootUp {
     CompaniesConnectorConjector.addAllDevicesToItsRepos(allDevices);
 
     CompaniesConnectorConjector.searchAllMdnsDevicesAndSetThemUp();
-    CompaniesConnectorConjector.searchPingableDevicesAndSetThemUpByHostName();
+
+    // TODO: ping command does not have the permission under snap.
+    // Bring back from comment after cbj-hub snap get the permission out of the box
+    // https://forum.snapcraft.io/t/request-auto-connect-firewall-control-or-network-control-or-network-observe-for-cbj-hub/31222
+    // CompaniesConnectorConjector.searchPingableDevicesAndSetThemUpByHostName();
 
     getIt<IMqttServerRepository>();
 


### PR DESCRIPTION
Removing searchPingableDevicesAndSetThemUpByHostName for now search for now as it ping does not have permission inside snap and it crash the program.