### PR TITLE
Fix ping scan now work inside snap

### DIFF
--- a/lib/application/boot_up/boot_up.dart
+++ b/lib/application/boot_up/boot_up.dart
@@ -32,9 +32,7 @@ class BootUp {
 
     CompaniesConnectorConjector.searchAllMdnsDevicesAndSetThemUp();
 
-    // TODO: ping command does not work under snap.
-    // https://github.com/CyBear-Jinni-user/CBJ_Hub_Snap/issues/2
-    // CompaniesConnectorConjector.searchPingableDevicesAndSetThemUpByHostName();
+    CompaniesConnectorConjector.searchPingableDevicesAndSetThemUpByHostName();
 
     getIt<IMqttServerRepository>();
 


### PR DESCRIPTION
Splitting ping requests to two parts and making it and each subnet run synchronicity to not overwhelm the system when running as a snap

This is a big move forward, now we can recognize devices in the network which do not support mDNS.
This was necessary for Tasmota to work (in the snap download of the project).


Fix: https://github.com/CyBear-Jinni-user/CBJ_Hub_Snap/issues/2